### PR TITLE
Code cov runtime

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -73,7 +73,7 @@ WITH_WEBSOCKETS:=no
 WITH_EC:=yes
 
 # Build man page documentation by default.
-WITH_DOCS:=yes
+WITH_DOCS:=no
 
 # Build with client support for SOCK5 proxy.
 WITH_SOCKS:=yes

--- a/config.mk
+++ b/config.mk
@@ -102,7 +102,7 @@ WITH_EPOLL:=yes
 WITH_BUNDLED_DEPS:=yes
 
 # Build with coverage options
-WITH_COVERAGE:=no
+WITH_COVERAGE:=yes
 
 # Build with unix domain socket support
 WITH_UNIX_SOCKETS:=yes

--- a/src/mosquitto.c
+++ b/src/mosquitto.c
@@ -41,6 +41,7 @@ Contributors:
 #include <signal.h>
 #include <stdio.h>
 #include <string.h>
+#include <stdlib.h>
 #ifdef WITH_SYSTEMD
 #  include <systemd/sd-daemon.h>
 #endif
@@ -55,6 +56,7 @@ Contributors:
 #include "memory_mosq.h"
 #include "misc_mosq.h"
 #include "util_mosq.h"
+
 
 struct mosquitto_db db;
 
@@ -434,7 +436,6 @@ static int pid__write(void)
 	}
 	return MOSQ_ERR_SUCCESS;
 }
-
 
 int main(int argc, char *argv[])
 {

--- a/src/signals.c
+++ b/src/signals.c
@@ -66,12 +66,14 @@ void handle_sigusr1(int signal)
 #endif
 }
 
-/* Signal handler for SIGUSR2 - print subscription / retained tree. */
+void __gcov_flush();
+
+/* Signal handler for SIGUSR2 - dump code coverage information during execution */
 void handle_sigusr2(int signal)
 {
 	UNUSED(signal);
 
-	flag_tree_print = true;
+	__gcov_flush(); 
 }
 
 /*


### PR DESCRIPTION
I have added a custom SIGUSR2 handle to dump code coverage information (.gcda files) during execution.

The project has to be compiled with `WITH_COVERAGE:=yes" flag (see `config.mk`), otherwise, the feature makes no sense.

This is enabled only on UNIX systems.  

Caveat: To implement this feature, I dropped the possibility of displaying the subscription tree via signals (see [man pages](https://mosquitto.org/man/mosquitto-8.html)).